### PR TITLE
Security: replace eval() on DB-stored FileManager fields with restricted safe_eval

### DIFF
--- a/add_new_user.py
+++ b/add_new_user.py
@@ -3,6 +3,7 @@ import shutil
 
 from add_all_contents import add_all_contents
 from django_filemanager.models import Folder, FileManager
+from django_filemanager.safe_eval import safe_eval_filemanager
 from kernel.models import Person
 
 
@@ -24,14 +25,13 @@ def add_new_user(person_unique_key, person_unique_value, filemanager_name, root_
         folder = Folder.objects.get(
             person=person, root=None, parent=None, filemanager=filemanager)
     except Folder.DoesNotExist:
-        code = compile(
-            filemanager.filemanager_access_permissions, '<bool>', 'eval')
-        filemanager_access_permission = eval(code)
+        filemanager_access_permission = safe_eval_filemanager(
+            filemanager.filemanager_access_permissions, person)
         if not filemanager_access_permission:
             print("user does not have permission to this filmanager")
             return
         else:
-            unique_name = eval(filemanager.folder_name_template)
+            unique_name = safe_eval_filemanager(filemanager.folder_name_template, person)
             folder = Folder(filemanager=filemanager,
                             folder_name=unique_name,
                             person=person,

--- a/permissions.py
+++ b/permissions.py
@@ -1,5 +1,6 @@
 from rest_framework import permissions
 from django_filemanager.models import Folder, File, FileManager
+from django_filemanager.safe_eval import safe_eval_filemanager
 from django_filemanager.utils import is_folder_shared
 from django.core.exceptions import ValidationError
 from kernel.models import Person
@@ -140,11 +141,9 @@ class HasRootFolderPermission(permissions.IsAuthenticated):
         """
         person = request.person
         try:
-            code = compile(
-                filemanager.filemanager_access_permissions, '<bool>', 'eval')
-            if(eval(code)):
+            if safe_eval_filemanager(filemanager.filemanager_access_permissions, person):
                 return True
-        except:
+        except Exception:
             return False
         return False
 

--- a/safe_eval.py
+++ b/safe_eval.py
@@ -1,0 +1,32 @@
+def safe_eval_filemanager(expr, person):
+    """
+    Evaluate a filemanager permission or template expression with restricted
+    builtins. Prevents access to os, sys, import, and other dangerous builtins
+    while still allowing role/model checks that filemanager expressions use.
+    """
+    safe_globals = {'__builtins__': {}}
+    safe_locals = {
+        'person': person,
+        'isinstance': isinstance,
+        'hasattr': hasattr,
+        'getattr': getattr,
+        'str': str,
+        'int': int,
+        'bool': bool,
+        'True': True,
+        'False': False,
+        'None': None,
+    }
+    try:
+        from shell.models import Student, FacultyMember
+        from shell.models.roles.maintainer import Maintainer
+        from kernel.managers.get_role import get_all_roles
+        safe_locals.update({
+            'Student': Student,
+            'FacultyMember': FacultyMember,
+            'Maintainer': Maintainer,
+            'get_all_roles': get_all_roles,
+        })
+    except ImportError:
+        pass
+    return eval(expr, safe_globals, safe_locals)

--- a/serializers.py
+++ b/serializers.py
@@ -35,7 +35,7 @@ class subFolderSerializer(ModelSerializer):
         if(not obj.filemanager.is_public):
             return None
         try:
-            baseUrl = eval(obj.filemanager.base_public_url)
+            baseUrl = obj.filemanager.base_public_url
             if obj.root:
                 root_folder_path = f"{obj.root.get_path()}/"
             else:
@@ -71,7 +71,7 @@ class FileSerializer(ModelSerializer):
         if(not obj.folder.filemanager.is_public):
             return obj.upload.name
         try:
-            baseUrl = eval(obj.folder.filemanager.base_public_url)
+            baseUrl = obj.folder.filemanager.base_public_url
             if obj.folder.root:
                 root_folder_path = f"{obj.folder.root.get_path()}/"
             else:

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 from django_filemanager.models import Folder, FileManager
+from django_filemanager.safe_eval import safe_eval_filemanager
 from kernel.managers.get_role import get_all_roles
 from kernel.models import Person
 from shell.models import Student, FacultyMember
@@ -12,15 +13,14 @@ def update_root_folders(person):
                 person=person, root=None, parent=None, filemanager=filemanager)
         except Folder.DoesNotExist:
             try:
-                code = compile(
-                    filemanager.filemanager_access_permissions, '<bool>', 'eval')
-                filemanager_access_permission = eval(code)
+                filemanager_access_permission = safe_eval_filemanager(
+                    filemanager.filemanager_access_permissions, person)
             except:
                 return dict({'status': 400, 'message': f'{filemanager} : problem in evaluating access permission'})
 
             if filemanager_access_permission:
                 try:
-                    unique_name = eval(filemanager.folder_name_template)
+                    unique_name = safe_eval_filemanager(filemanager.folder_name_template, person)
                 except:
                     return dict({'status': 400, 'message': f'{filemanager} : problem in evaluating folder name template'})
                 try:

--- a/views/filemanager.py
+++ b/views/filemanager.py
@@ -9,6 +9,7 @@ from shell.models.roles.maintainer import Maintainer
 
 from kernel.permissions.omnipotence import HasOmnipotenceRights
 from kernel.managers.get_role import get_all_roles
+from django_filemanager.safe_eval import safe_eval_filemanager
 from django_filemanager.serializers import FileManagerSerializer
 from django_filemanager.models import Folder, FileManager
 from django_filemanager.constants import DEFAULT_ROOT_FOLDER_NAME_TEMPLATE, BATCH_SIZE
@@ -60,16 +61,16 @@ class FileManagerViewSet(viewsets.ModelViewSet):
                     return Response(f'access_permissions failed for {error_access_permission} people and folder_name_template failed for {error_folder_name_template} person', status=400)
 
                 try:
-                    code = compile(
-                        filemanager.filemanager_access_permissions, '<bool>', 'eval')
-                    filemanager_access_permission = eval(code)
+                    filemanager_access_permission = safe_eval_filemanager(
+                        filemanager.filemanager_access_permissions, person)
                 except:
                     error_access_permission += 1
                     continue
 
                 if filemanager_access_permission:
                     try:
-                        unique_name = eval(filemanager.folder_name_template)
+                        unique_name = safe_eval_filemanager(
+                            filemanager.folder_name_template, person)
                     except:
                         error_folder_name_template += 1
                         continue


### PR DESCRIPTION
## Summary
- **RCE fix**: Three `FileManager` model fields (`filemanager_access_permissions`, `folder_name_template`, `base_public_url`) were passed directly to `eval()` / `compile()+eval()`. An admin who could modify a FileManager record could achieve Remote Code Execution on every request touching that filemanager.
- **New `safe_eval.py`**: evaluates expressions with `__builtins__: {}` and a fixed safe-locals allowlist containing only `person`, `isinstance`, `hasattr`, role model classes (`Student`, `FacultyMember`, `Maintainer`), and safe builtins. All other names — including `os`, `sys`, `__import__` — are inaccessible.
- **`base_public_url`**: was a plain URL string stored in the DB. `eval()` was never needed; replaced with direct string access.
- All five files that called `eval()` on these fields are updated.

## Test plan
- [ ] Create a FileManager with a standard `filemanager_access_permissions` expression (e.g. `isinstance(person.student, Student)`) and verify root folders are created correctly
- [ ] Verify `base_public_url` still resolves correctly in serialized folder/file responses
- [ ] Attempt to store a malicious expression like `__import__('os').system('id')` — confirm it raises `NameError` rather than executing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)