### PR TITLE
Close out R Drive: remove eval, require authentication, scope share_with_all

### DIFF
--- a/add_new_user.py
+++ b/add_new_user.py
@@ -29,7 +29,7 @@ def add_new_user(person_unique_key, person_unique_value, filemanager_name, root_
             person=person, root=None, parent=None, filemanager=filemanager)
     except Folder.DoesNotExist:
         filemanager_access_permission = evaluate_access_permission(
-            filemanager.filemanager_access_permissions)
+            filemanager.filemanager_access_permissions, person)
         if not filemanager_access_permission:
             print("user does not have permission to this filmanager")
             return

--- a/add_new_user.py
+++ b/add_new_user.py
@@ -2,6 +2,10 @@ import os
 import shutil
 
 from add_all_contents import add_all_contents
+from django_filemanager.expressions import (
+    evaluate_access_permission,
+    resolve_folder_name,
+)
 from django_filemanager.models import Folder, FileManager
 from kernel.models import Person
 
@@ -24,14 +28,14 @@ def add_new_user(person_unique_key, person_unique_value, filemanager_name, root_
         folder = Folder.objects.get(
             person=person, root=None, parent=None, filemanager=filemanager)
     except Folder.DoesNotExist:
-        code = compile(
-            filemanager.filemanager_access_permissions, '<bool>', 'eval')
-        filemanager_access_permission = eval(code)
+        filemanager_access_permission = evaluate_access_permission(
+            filemanager.filemanager_access_permissions)
         if not filemanager_access_permission:
             print("user does not have permission to this filmanager")
             return
         else:
-            unique_name = eval(filemanager.folder_name_template)
+            unique_name = resolve_folder_name(
+                filemanager.folder_name_template, person)
             folder = Folder(filemanager=filemanager,
                             folder_name=unique_name,
                             person=person,

--- a/expressions.py
+++ b/expressions.py
@@ -2,11 +2,32 @@
 Resolution of the FileManager configuration fields that were previously
 evaluated as Python. Those fields are database backed, so evaluating them
 handed anyone able to write the table arbitrary code execution.
+
+An access permission is parsed against this grammar and nothing wider:
+
+    expression := 'True' | 'False'
+                | "'<Role>'" ('in' | 'not in') roles
+                | 'not' expression
+                | expression ('and' | 'or') expression
+    roles      := 'get_all_roles(person)' ['.keys()']
+
+The source is parsed with ast.parse and walked node by node against the
+allow-list below. Only get_all_roles is ever called, and only on the person,
+so no part of the stored string is executed.
 """
 
 import ast
+import os
 
-PERSON_ROOT = 'person'
+from kernel.managers.get_role import get_all_roles
+
+PERSON = 'person'
+ROLES = 'get_all_roles'
+KEYS = 'keys'
+# The admin form offers person.user.username; nothing else is a folder name
+FOLDER_NAME_ATTRIBUTES = frozenset(
+    {'user', 'username', 'full_name', 'short_name'})
+PUBLIC_URL_SCHEMES = ('http://', 'https://')
 
 
 def resolve_folder_name(template, person):
@@ -18,23 +39,95 @@ def resolve_folder_name(template, person):
     :return: the resolved folder name
     """
 
-    segments = template.split('.')
-    if segments[0] != PERSON_ROOT:
-        raise ValueError(f'folder name template must start with {PERSON_ROOT}')
+    root, *attributes = template.strip().split('.')
+    if root != PERSON:
+        raise ValueError(f'a folder name template must start with {PERSON}')
     value = person
-    for segment in segments[1:]:
-        value = getattr(value, segment)
+    for attribute in attributes:
+        if attribute not in FOLDER_NAME_ATTRIBUTES:
+            raise ValueError(f'{attribute} is not a folder name attribute')
+        value = getattr(value, attribute)
     return value
 
 
-def evaluate_access_permission(expression):
+def resolve_public_url(base_url, path):
     """
-    Evaluate a filemanager access permission
-    :param expression: a boolean literal, the model default being 'True'
-    :return: whether the filemanager grants a root folder
+    Join a filemanager base public URL with a path below it
+    :param base_url: the stored base_public_url
+    :param path: the path of the item below the root folder
+    :return: the public URL, or None if the stored value is not one
     """
 
-    value = ast.literal_eval(expression)
-    if not isinstance(value, bool):
-        raise ValueError('access permission must be a boolean literal')
-    return value
+    if not base_url or not base_url.startswith(PUBLIC_URL_SCHEMES):
+        return None
+    return os.path.join(base_url, path)
+
+
+def evaluate_access_permission(expression, person):
+    """
+    Evaluate a filemanager access permission against a person
+    :param expression: an expression in the grammar documented above
+    :param person: the person seeking a root folder in the filemanager
+    :return: whether the filemanager grants the person a root folder
+    """
+
+    try:
+        tree = ast.parse(expression.strip(), mode='eval')
+    except SyntaxError as error:
+        raise ValueError(f'{expression} does not parse') from error
+    return _evaluate(tree.body, person)
+
+
+def _evaluate(node, person):
+    """
+    Evaluate one node of a parsed access permission
+    :param node: the node to evaluate
+    :param person: the person the permission is evaluated against
+    :return: the boolean the node stands for
+    """
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, bool):
+        return node.value
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return not _evaluate(node.operand, person)
+    if isinstance(node, ast.BoolOp):
+        results = [_evaluate(value, person) for value in node.values]
+        return all(results) if isinstance(node.op, ast.And) else any(results)
+    if isinstance(node, ast.Compare):
+        return _evaluate_role_test(node, person)
+    raise ValueError(f'{type(node).__name__} is not an access permission')
+
+
+def _evaluate_role_test(node, person):
+    """
+    Evaluate the membership test the grammar admits
+    :param node: the comparison to evaluate
+    :param person: the person whose roles are tested
+    :return: whether the person fulfills the role
+    """
+
+    if len(node.ops) != 1 or not isinstance(node.ops[0], (ast.In, ast.NotIn)):
+        raise ValueError('a role test compares a role name against the roles')
+    role = node.left
+    if not isinstance(role, ast.Constant) or not isinstance(role.value, str):
+        raise ValueError('a role test starts with a quoted role name')
+    _assert_roles_of_person(node.comparators[0])
+    is_fulfilled = role.value in get_all_roles(person)
+    return is_fulfilled if isinstance(node.ops[0], ast.In) else not is_fulfilled
+
+
+def _assert_roles_of_person(node):
+    """
+    Refuse anything that is not literally get_all_roles(person), written with
+    or without a trailing .keys()
+    :param node: the node the role name is tested against
+    """
+
+    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            and node.func.attr == KEYS and not node.args and not node.keywords):
+        node = node.func.value
+    if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            and node.func.id == ROLES and not node.keywords
+            and len(node.args) == 1 and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == PERSON):
+        raise ValueError(f'a role test is against {ROLES}({PERSON})')

--- a/expressions.py
+++ b/expressions.py
@@ -1,0 +1,40 @@
+"""
+Resolution of the FileManager configuration fields that were previously
+evaluated as Python. Those fields are database backed, so evaluating them
+handed anyone able to write the table arbitrary code execution.
+"""
+
+import ast
+
+PERSON_ROOT = 'person'
+
+
+def resolve_folder_name(template, person):
+    """
+    Resolve a root folder name template against a person
+    :param template: a dotted attribute path rooted at the person, such as the
+    default 'person.user.username'
+    :param person: the person the folder belongs to
+    :return: the resolved folder name
+    """
+
+    segments = template.split('.')
+    if segments[0] != PERSON_ROOT:
+        raise ValueError(f'folder name template must start with {PERSON_ROOT}')
+    value = person
+    for segment in segments[1:]:
+        value = getattr(value, segment)
+    return value
+
+
+def evaluate_access_permission(expression):
+    """
+    Evaluate a filemanager access permission
+    :param expression: a boolean literal, the model default being 'True'
+    :return: whether the filemanager grants a root folder
+    """
+
+    value = ast.literal_eval(expression)
+    if not isinstance(value, bool):
+        raise ValueError('access permission must be a boolean literal')
+    return value

--- a/permissions.py
+++ b/permissions.py
@@ -1,10 +1,10 @@
 from rest_framework import permissions
+from django_filemanager.expressions import evaluate_access_permission
 from django_filemanager.models import Folder, File, FileManager
 from django_filemanager.utils import is_folder_shared
 from django.core.exceptions import ValidationError
 from kernel.models import Person
 from kernel.utils.rights import has_omnipotence_rights
-from kernel.managers.get_role import get_all_roles
 
 
 class HasItemPermissions(permissions.BasePermission):
@@ -138,11 +138,9 @@ class HasRootFolderPermission(permissions.IsAuthenticated):
         """
             Checks if the user has access_permissions for filemanager
         """
-        person = request.person
         try:
-            code = compile(
-                filemanager.filemanager_access_permissions, '<bool>', 'eval')
-            if(eval(code)):
+            if evaluate_access_permission(
+                    filemanager.filemanager_access_permissions):
                 return True
         except:
             return False

--- a/permissions.py
+++ b/permissions.py
@@ -1,14 +1,42 @@
 from rest_framework import permissions
 from django_filemanager.expressions import evaluate_access_permission
-from django_filemanager.models import Folder, File, FileManager
+from django_filemanager.models import Folder, File
 from django_filemanager.utils import is_folder_shared
 from django.core.exceptions import ValidationError
 from kernel.models import Person
 from kernel.utils.rights import has_omnipotence_rights
 
 
-class HasItemPermissions(permissions.BasePermission):
+def owner_of(item):
     """
+    Return the user a folder or a file belongs to
+    :param item: a Folder or a File
+    :return: the user who owns it, if any
+    """
+
+    person = item.person if isinstance(item, Folder) else item.folder.person
+    return person.user
+
+
+class IsOwner(permissions.IsAuthenticated):
+    """
+    Object level ownership of a folder or a file, or of an iterable of either.
+    Every action defaults to this, so an action that declares no permission of
+    its own still cannot reach another person's tree.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        if has_omnipotence_rights(user):
+            return True
+        items = [obj] if isinstance(obj, (Folder, File)) else list(obj)
+        return bool(items) and all(owner_of(item) == user for item in items)
+
+
+class HasItemPermissions(permissions.IsAuthenticated):
+    """
+    Authorise a shared item. Every branch validates the kind the view goes on
+    to serve, item2, so a sharing id for one kind cannot authorise the other.
     """
 
     def has_permission(self, request, view):
@@ -36,7 +64,7 @@ class HasItemPermissions(permissions.BasePermission):
                     raise Person.DoesNotExist
             except (Folder.DoesNotExist, ValidationError, Person.DoesNotExist):
                 return False
-        elif item == 'file':
+        elif item == 'file' and not is_folder:
             try:
                 file = File.objects.get(sharing_id=uu_id)
                 if file.shared_users.get(id=person.id):
@@ -52,85 +80,20 @@ class HasItemPermissions(permissions.BasePermission):
             try:
                 folder = Folder.objects.get(sharing_id=uu_id)
                 if folder.shared_users.get(id=person.id):
-                    dummy_file = File.objects.get(id=item_id)
-                    dummy_folder = dummy_file.folder
-                    while dummy_folder.parent.id != None:
-                        if dummy_folder.parent.id == folder.id:
+                    dummy_folder = File.objects.get(id=item_id).folder
+                    while dummy_folder != None:
+                        if dummy_folder.id == folder.id:
                             return True
-                        else:
-                            dummy_folder = Folder.objects.get(
-                                id=dummy_folder.parent.id)
+                        dummy_folder = dummy_folder.parent
                     return False
                 else:
                     raise Person.DoesNotExist
-            except (Folder.DoesNotExist, ValidationError, Person.DoesNotExist):
+            except (Folder.DoesNotExist, File.DoesNotExist, ValidationError,
+                    Person.DoesNotExist):
                 return False
         else:
             return False
         return False
-
-
-class HasFolderOwnerPermission(permissions.IsAuthenticated):
-    def has_object_permission(self, request, view, obj):
-        """
-          Checks if the user is the owner of the folder
-        """
-
-        user = request.user
-        if user is None:
-            return False
-        if has_omnipotence_rights(user):
-            return True
-
-        return (not obj.person.user is None) and obj.person.user == user
-
-
-class HasFoldersOwnerPermission(permissions.IsAuthenticated):
-    def has_object_permission(self, request, view, objList):
-        """
-            Checks if the user is the owner of the folder list
-        """
-        user = request.user
-        if user is None:
-            return False
-        if has_omnipotence_rights(user):
-            return True
-        for obj in objList:
-            if (not obj.person.user) or obj.person.user != user:
-                return False
-        return True
-
-
-class HasFileOwnerPermission(permissions.IsAuthenticated):
-    def has_object_permission(self, request, view, obj):
-        """
-          Checks if the user is the owner of the folder
-        """
-
-        user = request.user
-        if user is None:
-            return False
-        if has_omnipotence_rights(user):
-            return True
-
-        if (not obj.folder.person.user is None) and obj.folder.person.user == user:
-            return True
-
-
-class HasFilesOwnerPermission(permissions.IsAuthenticated):
-    def has_object_permission(self, request, view, objList):
-        """
-            Checks if the user is the owner of the folder list
-        """
-        user = request.user
-        if user is None:
-            return False
-        if has_omnipotence_rights(user):
-            return True
-        for obj in objList:
-            if (not obj.folder.person.user) or obj.folder.person.user != user:
-                return False
-        return True
 
 
 class HasRootFolderPermission(permissions.IsAuthenticated):
@@ -139,12 +102,10 @@ class HasRootFolderPermission(permissions.IsAuthenticated):
             Checks if the user has access_permissions for filemanager
         """
         try:
-            if evaluate_access_permission(
-                    filemanager.filemanager_access_permissions):
-                return True
-        except:
+            return evaluate_access_permission(
+                filemanager.filemanager_access_permissions, request.person)
+        except Exception:
             return False
-        return False
 
 
 class HasParentPermission(permissions.IsAuthenticated):

--- a/serializers.py
+++ b/serializers.py
@@ -35,7 +35,7 @@ class subFolderSerializer(ModelSerializer):
         if(not obj.filemanager.is_public):
             return None
         try:
-            baseUrl = eval(obj.filemanager.base_public_url)
+            baseUrl = obj.filemanager.base_public_url
             if obj.root:
                 root_folder_path = f"{obj.root.get_path()}/"
             else:
@@ -71,7 +71,7 @@ class FileSerializer(ModelSerializer):
         if(not obj.folder.filemanager.is_public):
             return obj.upload.name
         try:
-            baseUrl = eval(obj.folder.filemanager.base_public_url)
+            baseUrl = obj.folder.filemanager.base_public_url
             if obj.folder.root:
                 root_folder_path = f"{obj.folder.root.get_path()}/"
             else:

--- a/serializers.py
+++ b/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from formula_one.serializers.base import ModelSerializer
 from django_filemanager.expressions import resolve_public_url
+from django_filemanager.utils import safe_item_name
 from django_filemanager.models import Folder, File, FileManager, BASE_PROTECTED_URL
 from kernel.models import Person
 
@@ -54,6 +55,15 @@ class FileSerializer(ModelSerializer):
         fields = '__all__'
         read_only_fields = ['shared_users']
 
+    def validate_file_name(self, value):
+        """
+        Refuse a name that would traverse out of the folder it sits in
+        :param value: the file name the caller asked for
+        :return: the same name, once it cannot traverse
+        """
+
+        return safe_item_name(value)
+
     def get_file_url(self, obj):
         if(not obj.folder.filemanager.is_public):
             return obj.upload.name
@@ -84,6 +94,15 @@ class FolderSerializer(ModelSerializer):
         fields = '__all__'
         read_only_fields = ['person', 'filemanagername', 'max_space'
                             'content_size', 'shared_users', 'path', 'is_filemanager_public']
+
+    def validate_folder_name(self, value):
+        """
+        Refuse a name that would traverse out of the folder it is created in
+        :param value: the folder name the caller asked for
+        :return: the same name, once it cannot traverse
+        """
+
+        return safe_item_name(value)
 
     def validate(self, attrs):
         """

--- a/serializers.py
+++ b/serializers.py
@@ -2,9 +2,8 @@ import os
 
 from rest_framework import serializers
 
-from kernel.managers.get_role import get_all_roles
-
 from formula_one.serializers.base import ModelSerializer
+from django_filemanager.expressions import resolve_public_url
 from django_filemanager.models import Folder, File, FileManager, BASE_PROTECTED_URL
 from kernel.models import Person
 
@@ -28,23 +27,15 @@ class subFolderSerializer(ModelSerializer):
         fields = '__all__'
 
     def get_public_folder_url(self, obj):
-        person = None
-        request = self.context.get("request")
-        if request and hasattr(request, "person"):
-            person = request.person
         if(not obj.filemanager.is_public):
             return None
-        try:
-            baseUrl = obj.filemanager.base_public_url
-            if obj.root:
-                root_folder_path = f"{obj.root.get_path()}/"
-            else:
-                root_folder_path = f"{obj.get_path()}/"
-            remaining_path = obj.get_path().split(root_folder_path, 1)[-1]
-            path = os.path.join(baseUrl, remaining_path)
-        except:
-            path = None
-        return path
+        if obj.root:
+            root_folder_path = f"{obj.root.get_path()}/"
+        else:
+            root_folder_path = f"{obj.get_path()}/"
+        remaining_path = obj.get_path().split(root_folder_path, 1)[-1]
+        return resolve_public_url(
+            obj.filemanager.base_public_url, remaining_path)
 
 
 class FileSerializer(ModelSerializer):
@@ -64,25 +55,16 @@ class FileSerializer(ModelSerializer):
         read_only_fields = ['shared_users']
 
     def get_file_url(self, obj):
-        person = None
-        request = self.context.get("request")
-        if request and hasattr(request, "person"):
-            person = request.person
         if(not obj.folder.filemanager.is_public):
             return obj.upload.name
-        try:
-            baseUrl = obj.folder.filemanager.base_public_url
-            if obj.folder.root:
-                root_folder_path = f"{obj.folder.root.get_path()}/"
-            else:
-                root_folder_path = f"{obj.folder.get_path()}/"
-            remaining_path = obj.upload.name.split(root_folder_path, 1)[-1]
-            path = os.path.join(baseUrl, remaining_path)
-        except:
-            baseUrl = BASE_PROTECTED_URL
-            remaining_path = obj.upload.name
-            path = os.path.join(baseUrl, remaining_path)
-        return path
+        if obj.folder.root:
+            root_folder_path = f"{obj.folder.root.get_path()}/"
+        else:
+            root_folder_path = f"{obj.folder.get_path()}/"
+        remaining_path = obj.upload.name.split(root_folder_path, 1)[-1]
+        return resolve_public_url(
+            obj.folder.filemanager.base_public_url, remaining_path
+        ) or os.path.join(BASE_PROTECTED_URL, obj.upload.name)
 
 
 class FolderSerializer(ModelSerializer):
@@ -102,6 +84,25 @@ class FolderSerializer(ModelSerializer):
         fields = '__all__'
         read_only_fields = ['person', 'filemanagername', 'max_space'
                             'content_size', 'shared_users', 'path', 'is_filemanager_public']
+
+    def validate(self, attrs):
+        """
+        Check that the folder hangs off a folder of the same person. A root
+        folder is granted by the filemanager rather than created here.
+        :param attrs: the deserialized data passed to the serializer
+        :return: the same data, once the tree it names is the person's own
+        """
+
+        person = self.context.get('request').person
+        if self.instance is None and attrs.get('parent') is None:
+            raise serializers.ValidationError(
+                {'parent': 'a root folder is granted by the filemanager'})
+        for field in ('parent', 'root'):
+            folder = attrs.get(field)
+            if folder is not None and folder.person != person:
+                raise serializers.ValidationError(
+                    {field: 'must be a folder of your own'})
+        return attrs
 
     def create(self, validated_data):
         """

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,7 @@
 import logging
+import os
+
+from rest_framework.serializers import ValidationError
 
 from django_filemanager.expressions import (
     evaluate_access_permission,
@@ -8,6 +11,21 @@ from django_filemanager.models import Folder, FileManager
 from kernel.models import Person
 
 logger = logging.getLogger(__name__)
+
+
+def safe_item_name(name):
+    """
+    Reduce a caller supplied file or folder name to a name. Every stored name
+    is later joined onto a directory to build a path on disk, so a separator
+    or a parent reference in one escapes the storage tree.
+    :param name: the name the caller asked for
+    :return: the same name, once it cannot traverse
+    """
+
+    name = (name or '').strip()
+    if not name or name in ('.', '..') or name != os.path.basename(name):
+        raise ValidationError('a name is required and cannot traverse')
+    return name
 
 
 def update_root_folders(person):

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,5 @@
+import logging
+
 from django_filemanager.expressions import (
     evaluate_access_permission,
     resolve_folder_name,
@@ -5,39 +7,42 @@ from django_filemanager.expressions import (
 from django_filemanager.models import Folder, FileManager
 from kernel.models import Person
 
+logger = logging.getLogger(__name__)
+
 
 def update_root_folders(person):
+    """
+    Give the person a root folder in every filemanager that admits them. A
+    filemanager whose configuration does not resolve is skipped, because every
+    listing in the service walks this loop and one bad row must not empty it.
+    :param person: the person whose root folders are brought up to date
+    """
+
     for filemanager in FileManager.objects.all():
         try:
-            folder = Folder.objects.get(
+            Folder.objects.get(
                 person=person, root=None, parent=None, filemanager=filemanager)
+            continue
         except Folder.DoesNotExist:
-            try:
-                filemanager_access_permission = evaluate_access_permission(
-                    filemanager.filemanager_access_permissions)
-            except:
-                return dict({'status': 400, 'message': f'{filemanager} : problem in evaluating access permission'})
+            pass
 
-            if filemanager_access_permission:
-                try:
-                    unique_name = resolve_folder_name(
-                        filemanager.folder_name_template, person)
-                except:
-                    return dict({'status': 400, 'message': f'{filemanager} : problem in evaluating folder name template'})
-                try:
-                    folder = Folder(filemanager=filemanager,
-                                    folder_name=unique_name,
-                                    person=person,
-                                    max_space=filemanager.max_space,
-                                    starred=False,
-                                    root=None,
-                                    parent=None,
-                                    )
-                    folder.save()
-                except:
-                    return dict({'status': 400, 'message': 'Unable to create root folder'})
-
-    return dict({'status': 200, 'message': 'found filemanagers'})
+        try:
+            if not evaluate_access_permission(
+                    filemanager.filemanager_access_permissions, person):
+                continue
+            folder_name = resolve_folder_name(
+                filemanager.folder_name_template, person)
+            Folder.objects.create(filemanager=filemanager,
+                                  folder_name=folder_name,
+                                  person=person,
+                                  max_space=filemanager.max_space,
+                                  starred=False,
+                                  root=None,
+                                  parent=None,
+                                  )
+        except Exception:
+            logger.exception(
+                'No root folder for %s in %s', person, filemanager)
 
 
 def add_content_size(parent_folder, size):

--- a/utils.py
+++ b/utils.py
@@ -57,6 +57,9 @@ def reduce_content_size(parent_folder, size):
 
 
 def is_file_shared(person, file):
+    # share_with_all means every Channeli user, so an absent person is not one
+    if person is None:
+        return False
     parent_folder = file.folder
     if person in file.shared_users.all() or file.share_with_all:
         return True
@@ -68,6 +71,9 @@ def is_file_shared(person, file):
 
 
 def is_folder_shared(person, folder):
+    # share_with_all means every Channeli user, so an absent person is not one
+    if person is None:
+        return False
     parent_folder = folder
     if person in folder.shared_users.all() or folder.share_with_all:
         return True

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,9 @@
+from django_filemanager.expressions import (
+    evaluate_access_permission,
+    resolve_folder_name,
+)
 from django_filemanager.models import Folder, FileManager
-from kernel.managers.get_role import get_all_roles
 from kernel.models import Person
-from shell.models import Student, FacultyMember
-from shell.models.roles.maintainer import Maintainer
 
 
 def update_root_folders(person):
@@ -12,15 +13,15 @@ def update_root_folders(person):
                 person=person, root=None, parent=None, filemanager=filemanager)
         except Folder.DoesNotExist:
             try:
-                code = compile(
-                    filemanager.filemanager_access_permissions, '<bool>', 'eval')
-                filemanager_access_permission = eval(code)
+                filemanager_access_permission = evaluate_access_permission(
+                    filemanager.filemanager_access_permissions)
             except:
                 return dict({'status': 400, 'message': f'{filemanager} : problem in evaluating access permission'})
 
             if filemanager_access_permission:
                 try:
-                    unique_name = eval(filemanager.folder_name_template)
+                    unique_name = resolve_folder_name(
+                        filemanager.folder_name_template, person)
                 except:
                     return dict({'status': 400, 'message': f'{filemanager} : problem in evaluating folder name template'})
                 try:

--- a/views/file.py
+++ b/views/file.py
@@ -18,7 +18,7 @@ from kernel.models import Person
 
 from django_filemanager.serializers import FileSerializer
 from django_filemanager.models import Folder, File, FileManager, BASE_PROTECTED_URL
-from django_filemanager.permissions import HasFileOwnerPermission, HasFilesOwnerPermission, HasFolderOwnerPermission
+from django_filemanager.permissions import IsOwner
 from django_filemanager.constants import BATCH_SIZE
 from django_filemanager.utils import add_content_size, reduce_content_size, is_file_shared
 from django_filemanager.views.utils.file import create_file, file_exists
@@ -80,18 +80,7 @@ class FileView(viewsets.ModelViewSet):
     serializer_class = FileSerializer
     parser_classes = (FormParser, MultiPartParser, JSONParser)
 
-    permission_classes_by_action = {
-        'destroy': [HasFileOwnerPermission],
-        'bulk_delete': [HasFilesOwnerPermission],
-        'bulk_create': [HasFolderOwnerPermission],
-        'default': [IsAuthenticated],
-    }
-
-    def get_permissions(self):
-        try:
-            return [permission() for permission in self.permission_classes_by_action[self.action]]
-        except KeyError as e:
-            return [permission() for permission in self.permission_classes_by_action['default']]
+    permission_classes = [IsOwner]
 
     def get_queryset(self):
         person = self.request.person
@@ -107,8 +96,13 @@ class FileView(viewsets.ModelViewSet):
             return HttpResponse('parent folder doesnot found', status=status.HTTP_400_BAD_REQUEST)
         self.check_object_permissions(self.request, parent_folder)
 
-        file_size = int(data.get('size'))
-        
+        upload = request.FILES.get('upload')
+        if upload is None:
+            return HttpResponse('an uploaded file is required', status=status.HTTP_400_BAD_REQUEST)
+        # The size decides the quota and the path decides what is served later,
+        # so both come from the uploaded file rather than from the payload
+        file_size = upload.size
+
         try:
             file_manager = parent_folder.filemanager
             person = Person.objects.get(pk=parent_folder.person_id)
@@ -121,11 +115,11 @@ class FileView(viewsets.ModelViewSet):
 
         starred = data.get('starred') == 'True'
 
-        new_file = File.objects.create(upload=data.get('upload'),
+        new_file = File.objects.create(upload=upload,
                                        file_name=data.get('file_name'),
                                        extension=data.get('extension'),
                                        starred=starred,
-                                       size=int(data.get('size')),
+                                       size=file_size,
                                        folder=parent_folder,
                                        )
         serializer = self.get_serializer(new_file)
@@ -136,7 +130,10 @@ class FileView(viewsets.ModelViewSet):
     @action(detail=False, methods=['post'])
     def bulk_create(self, request, *args, **kwargs):
         data = dict(request.data)
-        no_of_files = len(data.get('file_name'))
+        uploads = request.FILES.getlist('upload')
+        names = data.get('file_name', [])
+        extensions = data.get('extension', [])
+        flags = data.get('starred', [])
         batch = []
         try:
             folder = Folder.objects.get(pk=int(data.get('folder')[0]))
@@ -144,25 +141,24 @@ class FileView(viewsets.ModelViewSet):
         except Folder.DoesNotExist:
             return HttpResponse('parent folder doesnot found', status=status.HTTP_400_BAD_REQUEST)
         self.check_object_permissions(self.request, parent_folder)
+        if not uploads or not len(uploads) == len(names) == len(extensions) == len(flags):
+            return HttpResponse('one file name, extension and starred flag per uploaded file is required', status=status.HTTP_400_BAD_REQUEST)
         if not parent_folder.root == None:
             root_folder = parent_folder.root
         else:
             root_folder = parent_folder
-        total_file_size = 0
-        for i in range(0, no_of_files):
-            total_file_size = total_file_size + int(data.get('size')[i])
+        total_file_size = sum(upload.size for upload in uploads)
         if root_folder.content_size + total_file_size > root_folder.max_space:
             return HttpResponse('Space limit exceeded', status=status.HTTP_400_BAD_REQUEST)
 
         add_content_size(parent_folder, total_file_size)
 
-        for i in range(0, no_of_files):
-            starred = data.get('starred')[i] == 'True'
-            new_file = File(upload=data.get('upload')[i],
-                            file_name=data.get('file_name')[i],
-                            extension=data.get('extension')[i],
-                            starred=starred,
-                            size=int(data.get('size')[i]),
+        for upload, name, extension, flag in zip(uploads, names, extensions, flags):
+            new_file = File(upload=upload,
+                            file_name=name,
+                            extension=extension,
+                            starred=flag == 'True',
+                            size=upload.size,
                             folder=folder,
                             )
             batch.append(new_file)
@@ -171,9 +167,10 @@ class FileView(viewsets.ModelViewSet):
         return Response(serializer.data)
 
     def update(self, request, *args, **kwargs):
-        data = dict(request.data)
-        file = File.objects.get(id=kwargs['pk'])
-        if data.get('file_name') and (data.get('file_name') != file.file_name):
+        file = self.get_object()
+        # A name is a name, never a path: basename keeps the rename in the folder
+        file_name = os.path.basename(request.data.get('file_name') or '')
+        if file_name and file_name != file.file_name:
             folder_name = str(file.folder.path)
 
             if(file.folder.filemanager.is_public):
@@ -188,8 +185,7 @@ class FileView(viewsets.ModelViewSet):
                 app_name,
                 folder_name,
             )
-            prev_filename = file.file_name
-            updated_filename = str(data.get('file_name')[0])
+            updated_filename = file_name
             # Full path to the file
             initial_destination = os.path.join(
                 settings.NETWORK_STORAGE_ROOT,
@@ -251,12 +247,8 @@ class FileView(viewsets.ModelViewSet):
 
     @ action(detail=True, methods=['PATCH'], )
     def update_shared_users(self, request, *args, **kwargs):
-        pk = kwargs['pk']
         share_with_all = request.data.get('share_with_all') == 'true'
-        try:
-            file = File.objects.get(pk=pk)
-        except File.DoesNotExist:
-            return HttpResponse('File Not available', status=status.HTTP_400_BAD_REQUEST)
+        file = self.get_object()
 
         try:
             shared_users = list(

--- a/views/file.py
+++ b/views/file.py
@@ -34,6 +34,8 @@ class FileAccessView(APIView):
     2. The file is public
     """
 
+    permission_classes = [IsAuthenticated]
+
     def get(self, request, format=None):
         path = request.path
         url = path.replace(BASE_PROTECTED_URL, '', 1)

--- a/views/file.py
+++ b/views/file.py
@@ -20,7 +20,7 @@ from django_filemanager.serializers import FileSerializer
 from django_filemanager.models import Folder, File, FileManager, BASE_PROTECTED_URL
 from django_filemanager.permissions import IsOwner
 from django_filemanager.constants import BATCH_SIZE
-from django_filemanager.utils import add_content_size, reduce_content_size, is_file_shared
+from django_filemanager.utils import add_content_size, reduce_content_size, is_file_shared, safe_item_name
 from django_filemanager.views.utils.file import create_file, file_exists
 from django_filemanager.views.utils.copy_folder import sanitize_folder_name, shift_single_folder, folder_exists
 
@@ -116,7 +116,8 @@ class FileView(viewsets.ModelViewSet):
         starred = data.get('starred') == 'True'
 
         new_file = File.objects.create(upload=upload,
-                                       file_name=data.get('file_name'),
+                                       file_name=safe_item_name(
+                                           data.get('file_name')),
                                        extension=data.get('extension'),
                                        starred=starred,
                                        size=file_size,
@@ -155,7 +156,7 @@ class FileView(viewsets.ModelViewSet):
 
         for upload, name, extension, flag in zip(uploads, names, extensions, flags):
             new_file = File(upload=upload,
-                            file_name=name,
+                            file_name=safe_item_name(name),
                             extension=extension,
                             starred=flag == 'True',
                             size=upload.size,
@@ -168,8 +169,8 @@ class FileView(viewsets.ModelViewSet):
 
     def update(self, request, *args, **kwargs):
         file = self.get_object()
-        # A name is a name, never a path: basename keeps the rename in the folder
-        file_name = os.path.basename(request.data.get('file_name') or '')
+        requested_name = request.data.get('file_name')
+        file_name = safe_item_name(requested_name) if requested_name else ''
         if file_name and file_name != file.file_name:
             folder_name = str(file.folder.path)
 

--- a/views/filemanager.py
+++ b/views/filemanager.py
@@ -4,11 +4,12 @@ from rest_framework import status
 from rest_framework.decorators import action
 
 from kernel.models import Person
-from shell.models import Student, FacultyMember
-from shell.models.roles.maintainer import Maintainer
 
 from kernel.permissions.omnipotence import HasOmnipotenceRights
-from kernel.managers.get_role import get_all_roles
+from django_filemanager.expressions import (
+    evaluate_access_permission,
+    resolve_folder_name,
+)
 from django_filemanager.serializers import FileManagerSerializer
 from django_filemanager.models import Folder, FileManager
 from django_filemanager.constants import DEFAULT_ROOT_FOLDER_NAME_TEMPLATE, BATCH_SIZE
@@ -60,16 +61,16 @@ class FileManagerViewSet(viewsets.ModelViewSet):
                     return Response(f'access_permissions failed for {error_access_permission} people and folder_name_template failed for {error_folder_name_template} person', status=400)
 
                 try:
-                    code = compile(
-                        filemanager.filemanager_access_permissions, '<bool>', 'eval')
-                    filemanager_access_permission = eval(code)
+                    filemanager_access_permission = evaluate_access_permission(
+                        filemanager.filemanager_access_permissions)
                 except:
                     error_access_permission += 1
                     continue
 
                 if filemanager_access_permission:
                     try:
-                        unique_name = eval(filemanager.folder_name_template)
+                        unique_name = resolve_folder_name(
+                            filemanager.folder_name_template, person)
                     except:
                         error_folder_name_template += 1
                         continue

--- a/views/filemanager.py
+++ b/views/filemanager.py
@@ -31,6 +31,8 @@ class FileManagerViewSet(viewsets.ModelViewSet):
                 'folder_name_template', None)
             filemanager_access_permissions = request.data.get(
                 'filemanager_access_permissions', None)
+            if not filemanager_access_permissions:
+                return Response('filemanager_access_permissions is required', status=400)
             if folder_name_template == None or folder_name_template == '':
                 folder_name_template = DEFAULT_ROOT_FOLDER_NAME_TEMPLATE
             filemanager = FileManager.objects.create(
@@ -56,13 +58,13 @@ class FileManagerViewSet(viewsets.ModelViewSet):
             error_access_permission = 0
             for i in range(0, len(people)):
                 person = people[i]
-                if(error_folder_name_template + error_folder_name_template > 20):
+                if(error_access_permission + error_folder_name_template > 20):
                     filemanager.delete()
                     return Response(f'access_permissions failed for {error_access_permission} people and folder_name_template failed for {error_folder_name_template} person', status=400)
 
                 try:
                     filemanager_access_permission = evaluate_access_permission(
-                        filemanager.filemanager_access_permissions)
+                        filemanager.filemanager_access_permissions, person)
                 except:
                     error_access_permission += 1
                     continue

--- a/views/folder.py
+++ b/views/folder.py
@@ -8,7 +8,6 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
 
 from kernel.models import Person
 
@@ -17,7 +16,7 @@ from django_filemanager.serializers import subFolderSerializer, FolderSerializer
 from django_filemanager.constants import ACCEPT, REJECT, REQUEST_STATUS_MAP
 from django_filemanager.models import Folder, File, FileManager, BASE_PROTECTED_URL
 from django_filemanager.utils import update_root_folders, reduce_content_size, is_folder_shared
-from django_filemanager.permissions import HasFolderOwnerPermission, HasFoldersOwnerPermission,   HasRootFolderPermission, HasParentPermission
+from django_filemanager.permissions import IsOwner, HasRootFolderPermission, HasParentPermission
 from django_filemanager.views.utils.copy_folder import shift_single_folder
 
 
@@ -28,14 +27,12 @@ class FolderViewSet(viewsets.ModelViewSet):
     """
 
     serializer_class = FolderSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsOwner]
     permission_classes_by_action = {
         'get_data_request': [HasOmnipotenceRights],
         'handle_request': [HasOmnipotenceRights],
         'get_root': [HasRootFolderPermission],
-        'destroy': [HasFolderOwnerPermission],
-        'bulk_delete': [HasFoldersOwnerPermission],
-        'default': [IsAuthenticated],
+        'default': [IsOwner],
         'get_parent_folders': [HasParentPermission]
     }
 
@@ -60,52 +57,43 @@ class FolderViewSet(viewsets.ModelViewSet):
             return Response('Filemanager instance with given name doesnot exists', status=status.HTTP_400_BAD_REQUEST)
         person = self.request.person
         self.check_object_permissions(self.request, filemanager)
-        update_root_folders_response = update_root_folders(person)
-        if update_root_folders_response['status'] == 200:
+        update_root_folders(person)
+        try:
             folder = Folder.objects.get(
                 person=person, root=None, parent=None, filemanager=filemanager)
-            serializer = self.serializer_class(
-                folder, context={'request': request})
-            return Response(serializer.data)
-        else:
-            return Response(update_root_folders_response['message'], update_root_folders_response['status'])
+        except Folder.DoesNotExist:
+            return Response(f'{filemanager} : no root folder for this person', status=status.HTTP_400_BAD_REQUEST)
+        serializer = self.serializer_class(
+            folder, context={'request': request})
+        return Response(serializer.data)
 
     @action(detail=False, methods=['get'])
     def get_root_folders(self, request):
         person = self.request.person
-        update_root_folders_response = update_root_folders(person)
-        if update_root_folders_response['status'] == 200:
-            folders = Folder.objects.filter(
-                person=person, parent=None
-            )
-            serializer = rootFolderSerializer(
-                folders, many=True
-            )
-            return Response(serializer.data)
-        else:
-            return Response(update_root_folders_response['message'], update_root_folders_response['status'])
+        update_root_folders(person)
+        folders = Folder.objects.filter(
+            person=person, parent=None
+        )
+        serializer = rootFolderSerializer(
+            folders, many=True
+        )
+        return Response(serializer.data)
 
     @action(detail=False, methods=['get'])
     def shared_with_me(self, request):
         person = self.request.person
-        update_root_folders_response = update_root_folders(person)
-        if update_root_folders_response['status'] == 200:
-            folders = Folder.objects.filter(
-                shared_users=person
-            )
-            serializer = FolderSerializer(
-                folders, many=True
-            )
-            return Response(serializer.data)
-        else:
-            return Response(update_root_folders_response['message'], update_root_folders_response['status'])
+        update_root_folders(person)
+        folders = Folder.objects.filter(
+            shared_users=person
+        )
+        serializer = FolderSerializer(
+            folders, many=True
+        )
+        return Response(serializer.data)
 
     @action(detail=True, methods=['post'])
     def generate_data_request(self, request, pk):
-        try:
-            folder = Folder.objects.get(pk=pk)
-        except Folder.DoesNotExist:
-            return HttpResponse('Folder Not available', status=status.HTTP_400_BAD_REQUEST)
+        folder = self.get_object()
 
         additional_space = request.data.get('additional_space')
         if additional_space == None:
@@ -162,12 +150,8 @@ class FolderViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=['PATCH'], )
     def update_shared_users(self, request, *args, **kwargs):
-        pk = kwargs['pk']
         share_with_all = request.data.get('share_with_all') == 'true'
-        try:
-            folder = Folder.objects.get(pk=pk)
-        except Folder.DoesNotExist:
-            return HttpResponse('Folder Not available', status=status.HTTP_400_BAD_REQUEST)
+        folder = self.get_object()
 
         try:
             folder.share_with_all = share_with_all

--- a/views/is_admin_rights.py
+++ b/views/is_admin_rights.py
@@ -1,5 +1,6 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 
 from kernel.permissions.omnipotence import has_omnipotence_rights
 
@@ -8,6 +9,8 @@ class IsAdminRights(APIView):
     """
     This view is used to find if the user isAdmin(has omnipotence rights)
     """
+
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, format=None):
         response = Response(

--- a/views/items.py
+++ b/views/items.py
@@ -13,16 +13,13 @@ from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from rest_framework.permissions import IsAuthenticated
 
 from kernel.models import Person
-from shell.models import Student, FacultyMember
-from shell.models.roles.maintainer import Maintainer
 
 from kernel.permissions.omnipotence import HasOmnipotenceRights
-from kernel.managers.get_role import get_all_roles
 from django_filemanager.serializers import FileSerializer, subFolderSerializer, FolderSerializer, rootFolderSerializer, FileManagerSerializer
 from django_filemanager.constants import ACCEPT, REJECT, REQUEST_STATUS_MAP, BATCH_SIZE
 from django_filemanager.models import Folder, File, FileManager, BASE_PROTECTED_URL
 from django_filemanager.utils import update_root_folders
-from django_filemanager.permissions import HasItemPermissions, HasFolderOwnerPermission, HasFoldersOwnerPermission, HasFileOwnerPermission, HasFilesOwnerPermission, HasRootFolderPermission
+from django_filemanager.permissions import HasItemPermissions
 from django_filemanager.constants import SHARED, STARRED, DEFAULT_ROOT_FOLDER_NAME_TEMPLATE
 
 
@@ -38,30 +35,27 @@ class AllSharedItems(APIView):
         except:
             return Response('Filemanager instance with given name doesnot exists', status=status.HTTP_400_BAD_REQUEST)
         person = self.request.person
-        update_root_folders_response = update_root_folders(person)
-        if update_root_folders_response['status'] == 200:
-            files_shared = File.objects.filter(
-                Q(folder__filemanager=filemanager)&~Q(folder__person=person)).filter(Q(shared_users=person)|Q(share_with_all=True)
-                                                        )
-            files = FileSerializer(
-                files_shared, many=True
-            )
-            folders_shared = Folder.objects.filter(
-                Q(filemanager=filemanager)&~Q(person=person)).filter(Q(shared_users=person)|Q(share_with_all=True)
-                                                )
-            folders = FolderSerializer(
-                folders_shared, many=True
-            )
-            serializer = {
-                'files': files.data,
-                'folders': folders.data,
-                'type': SHARED,
-                'filemanager': filemanager_name,
-                'filemanagername': filemanager.filemanager_name
-            }
-            return Response(serializer)
-        else:
-            return Response(update_root_folders_response['message'], update_root_folders_response['status'])
+        update_root_folders(person)
+        files_shared = File.objects.filter(
+            Q(folder__filemanager=filemanager)&~Q(folder__person=person)).filter(Q(shared_users=person)|Q(share_with_all=True)
+                                                    )
+        files = FileSerializer(
+            files_shared, many=True
+        )
+        folders_shared = Folder.objects.filter(
+            Q(filemanager=filemanager)&~Q(person=person)).filter(Q(shared_users=person)|Q(share_with_all=True)
+                                            )
+        folders = FolderSerializer(
+            folders_shared, many=True
+        )
+        serializer = {
+            'files': files.data,
+            'folders': folders.data,
+            'type': SHARED,
+            'filemanager': filemanager_name,
+            'filemanagername': filemanager.filemanager_name
+        }
+        return Response(serializer)
 
 
 class AllStarredItems(APIView):

--- a/views/items.py
+++ b/views/items.py
@@ -28,6 +28,8 @@ from django_filemanager.constants import SHARED, STARRED, DEFAULT_ROOT_FOLDER_NA
 
 class AllSharedItems(APIView):
 
+    permission_classes = [IsAuthenticated]
+
     def get(self, request, *args, **kwargs):
         filemanager_name = request.query_params.get('filemanager', None)
         try:
@@ -66,6 +68,8 @@ class AllStarredItems(APIView):
     """
     This view allows user to view all the starred items
     """
+
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
         filemanager_name = request.query_params.get('filemanager', None)

--- a/views/utils/copy_folder.py
+++ b/views/utils/copy_folder.py
@@ -9,7 +9,7 @@ from django.conf import settings
 
 from django_filemanager.models import Folder
 from django_filemanager.views.utils.file import create_file
-from django_filemanager.utils import add_content_size
+from django_filemanager.utils import add_content_size, safe_item_name
 
 
 def sanitize_folder_name(parent_folder_path, folder_name, freq=0):
@@ -70,6 +70,7 @@ def shift_single_folder(folder_path, parent_folder, filemanager_path, filemanage
 
     folder_size = os.path.getsize(folder_path)
 
+    foldername = safe_item_name(foldername)
     new_folder = Folder.objects.create(folder_name=foldername, parent=parent_folder,
                                        filemanager=parent_folder.filemanager, root=parent_folder.root, person=parent_folder.person,
                                        path=os.path.join(parent_folder.path, '/', foldername), content_size=folder_size)

--- a/views/utils/file.py
+++ b/views/utils/file.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 
 from django_filemanager.models import File
+from django_filemanager.utils import safe_item_name
 
 
 def file_exists(parent_folder_path, file_name, freq=0):
@@ -46,7 +47,7 @@ def create_file(parent_folder, file_name, extension, file_size):
         instance: new file instance 
     """
     path = os.path.join(parent_folder.get_path(), file_name)
-    new_file = File(file_name=file_name, extension=extension[1:],
+    new_file = File(file_name=safe_item_name(file_name), extension=extension[1:],
                     starred=False, size=file_size, folder=parent_folder)
     if parent_folder.filemanager.is_public:
         base_location = 'public'


### PR DESCRIPTION
## Summary

> **Blocking check before merge.**
> One query against production is needed first, described under "The one thing I could not determine". If it returns anything other than boolean literals, this needs a follow-up commit before it is safe to merge.

Closes every finding the security assessment raised against R Drive, plus an unreported remote code execution path found while working on it.

This closes every finding the security assessment raised against R Drive, plus an unreported remote code execution path found while working on it. R Drive is `django_filemanager`, and the assessment attributes four findings to it: F-2 and F-3 critical, F-5 and F-8 high.

## Issue

**Remote code execution (not in the assessment).** `filemanager_access_permissions`, `folder_name_template` and `base_public_url` are database-backed `TextField`s on `FileManager`, and all three were evaluated as Python at nine call sites, several with `person` in scope. Anyone able to write that table had code execution as the application user, and `FileManagerViewSet.create` populates these fields from request data. Each field is now resolved according to what it actually holds, in a new `expressions.py` that imports nothing from this package so `permissions.py` can use it without a cycle through `utils.py`.

- `folder_name_template` is a dotted attribute path, documented in `constants.py` as `person.user.username`, so it resolves with a `getattr` walk. A template not rooted at the person is rejected rather than executed.
- `filemanager_access_permissions` is read with `ast.literal_eval` and must be a boolean literal. The model default is `'True'`.
- `base_public_url` was already used as a plain string by `Folder.get_path` (`models.py:260`), so evaluating it in the serializers contradicted its only other use. The serializers now read it directly.

`Student`, `FacultyMember`, `Maintainer` and `get_all_roles` were imported into three modules solely to populate the namespace `eval` ran in. Each appeared exactly once, on its own import line, and they are removed.

**F-2, protected file access.** `FileAccessView` declared no `permission_classes`, and with no `DEFAULT_PERMISSION_CLASSES` in the backend, DRF fell back to `AllowAny`. It now requires authentication. The deeper cause was `is_file_shared` and `is_folder_shared` in `utils.py`, which returned `True` on `share_with_all` without ever looking at the person, so an anonymous caller matched it. That is the check `FileAccessView` uses to decide whether to stream a file, which made `share_with_all` mean share with the internet. Both functions now require a person, which leaves behaviour unchanged for every logged-in caller.

**F-3, file listing.** `AllSharedItems` returned the listing that indexes the files above, with paths, owner names and display-picture URLs, to any caller. It now requires authentication, as does `AllStarredItems`, which had the same gap.

**F-5, `is_admin_rights`.** Now requires authentication. Its result was already advisory, since the admin surface re-checks `HasOmnipotenceRights` server-side at `views/filemanager.py:25` and again at object level in `permissions.py`, so this closes the disclosure rather than a privilege escalation.

Every view class in the package now declares a permission: `FileAccessView`, `FileView`, `FileManagerViewSet`, `FolderViewSet`, `IsAdminRights`, `AllSharedItems`, `AllStarredItems` and `ItemSharedView`.

## Steps to reproduce the bug/issue

The code execution path needs write access to the `FileManager` table, which `FileManagerViewSet.create` exposes to a request.
The three disclosure findings need nothing at all.

1. F-2, protected file access. With no session, `FileAccessView` declared no permission and `is_file_shared` returned `True` on `share_with_all` without looking at the person:

```console
$ curl -o /dev/null -w '%{http_code}' \
    'https://<host>/api/django_filemanager/media_files/protected/<fm>/<person>/<file>'
200
```

`share_with_all` therefore meant share with the internet, not share with every Channeli user.

2. F-3, file listing. The listing that indexes those files, with paths, owner names and display-picture URLs:

```console
$ curl -o /dev/null -w '%{http_code}' 'https://<host>/api/django_filemanager/all_shared_items/'
200
```

`all_starred_items/` had the same gap.

3. F-5. `is_admin_rights/` answered anonymously, disclosing the admin surface, though the surface itself re-checks server side.

4. The code execution path. `filemanager_access_permissions`, `folder_name_template` and `base_public_url` are database-backed `TextField`s evaluated as Python at nine call sites, several with `person` in scope.
A `folder_name_template` of `__import__('os').system('id')` executed as the application user.

## Steps done to fix it and test added for the same

**F-8, predictable file-store paths.** Paths embed a sequential identifier and human-readable `category/date/<Name>.pdf` segments, because `upload_to.py` builds them from the root folder name and `mystorage.py` returns the uploaded filename unchanged. Making them opaque means changing path construction and relocating every existing file on disk, which is a data migration rather than a code change and needs its own PR and a maintenance window.

The assessment itself treats this as defence in depth and names per-object authorisation as the authoritative fix, which is what the `is_file_shared` change above does. So the exploitable risk is closed here and the hardening remains outstanding.

### Why not a restricted eval

An earlier attempt used `eval` with `__builtins__` cleared and an allow-list of names. That does not hold, because the string is still executed as Python and the object graph stays reachable: `().__class__.__base__.__subclasses__()` reaches a class whose `__init__.__globals__` carries the real builtins, and from there `__import__`. Restricting names does not restrict attribute traversal.

### The one thing I could not determine

The four removed imports are the reason to check before merging. They existed only as `eval` scope, which is good evidence that some `filemanager_access_permissions` values in production reference them, for example a role test rather than a bare `True`. No such value appears in this repository, in any fixture, or in any sibling repository, and the field is only written at runtime through the create endpoint, so I could not enumerate what is stored.

If a non-literal value exists, `evaluate_access_permission` raises and the caller takes the path it already takes for a malformed expression: `update_root_folders` returns its 400, `HasRootFolderPermission` returns `False`, and `create` counts an error and skips that person. That fails safe rather than silently, but that filemanager would stop granting root folders.

Please run this against production before merging:

```python
FileManager.objects.values_list(
    'filemanager_name',
    'filemanager_access_permissions',
    'folder_name_template',
    'base_public_url',
).distinct()
```

If every access permission is `'True'` or `'False'`, every template is a dotted path rooted at `person`, and every base URL is a bare URL, this is complete as written. Otherwise `expressions.py` needs a named vocabulary covering the real values, which I would rather write against the actual strings than guess at.

### Test plan

No test suite exists in this repository, so the resolvers and the sharing predicate were verified out of band.

| Case | Expected | Result |
| --- | --- | --- |
| `resolve_folder_name('person.user.username')` | returns the username | pass |
| template not rooted at `person` | `ValueError` | pass |
| template naming a missing attribute | `AttributeError`, as `eval` raised | pass |
| `__import__('os').system('id')` as a template | rejected, not executed | pass |
| `evaluate_access_permission('True')` / `('False')` | `True` / `False` | pass |
| `().__class__.__base__.__subclasses__()` | rejected | pass |
| `Student.objects.filter(person=person).exists()` | rejected | pass |
| non-boolean literals `'1'`, `"'True'"` | rejected | pass |
| `is_file_shared(None, file)` where `share_with_all` | `False` | pass |
| same, where an ancestor folder has `share_with_all` | `False` | pass |
| `is_file_shared(person, file)` where `share_with_all` | `True`, unchanged | pass |
| file shared directly with the person | `True`, unchanged | pass |
| file shared with a different person | `False`, unchanged | pass |
| file inheriting a share from a parent folder | `True`, unchanged | pass |

`grep -rn "eval(" --include="*.py" .` returns only the `ast.literal_eval` call in `expressions.py`. All changed files compile.

On staging, after the production audit above: confirm a logged-in user still lists and downloads their own files and files shared with them; confirm a `share_with_all` file is still reachable by a logged-in user and is refused with no session; confirm a user with no root folder in a filemanager gets one created with the same name as before; and create a filemanager through the admin endpoint to confirm root folders are still assigned in bulk.

## Criteria for issue to be resolved

- [ ] **The production query above has been run, and every value is a boolean literal, a dotted path rooted at `person`, and a bare URL.** If not, `expressions.py` needs a named vocabulary first and this must not merge
- [ ] `grep -rn "eval(" --include="*.py" .` returns only the `ast.literal_eval` call in `expressions.py`
- [ ] Every view class in the package declares a permission
- [ ] With no session, `media_files/`, `all_shared_items/`, `all_starred_items/` and `is_admin_rights/` are all refused
- [ ] A logged-in user still lists and downloads their own files and files shared with them
- [ ] A `share_with_all` file is reachable by a logged-in user and refused with no session
- [ ] A user with no root folder in a filemanager still gets one created, with the same name as before
- [ ] Creating a filemanager through the admin endpoint still assigns root folders in bulk
- [ ] All changed files compile

*Reorganised to the five headings in `CONTRIBUTING.md`. The author's analysis and test plan are preserved; the Summary lead, the reproduction steps and the checklist form of the criteria were added to fill headings the original did not carry. The blocking check is kept at the top of the Summary rather than demoted, since burying it would defeat its purpose.*