### PR TITLE
Store uploads under opaque names and relocate the existing ones

### DIFF
--- a/add_all_contents.py
+++ b/add_all_contents.py
@@ -1,33 +1,10 @@
 import os
-import shutil
 
-from django_filemanager.upload_to import UploadTo
-
-from django.conf import settings
 from django.core.files import File as DjangoFile
 from django_filemanager.models import Folder, File
 
 from django_filemanager.constants import BATCH_SIZE
 from django_filemanager.utils import add_content_size
-
-def get_file_name(file, fileName):
-    """
-    Return Updated file name in case of file already exists
-    :param path: path of folder in which the file will be stored
-    :param filename: the original name of the file
-    :return: updated file name and the path to the uploaded file
-    """
-    new_file_rel_path = UploadTo(
-        "", "", file_manager=True)(file, fileName)
-    newname = fileName
-    counter = 0
-    name, ext = os.path.splitext(fileName)
-    while os.path.exists(os.path.join(settings.NETWORK_STORAGE_ROOT, new_file_rel_path)):
-        newname = name+'_' + str(counter) + ext
-        new_file_rel_path = os.path.dirname(new_file_rel_path)+'/'+newname
-        counter = counter + 1
-
-    return newname, new_file_rel_path
 
 def add_all_contents(parent_folder_path, person, root_folder, parent_folder, filemanager):
     """
@@ -53,15 +30,8 @@ def add_all_contents(parent_folder_path, person, root_folder, parent_folder, fil
             folder=parent_folder,
         )
 
-        newFileName, newFilePath = get_file_name(new_file, fileName)
-
-        src_file = os.path.join(
-            settings.NETWORK_STORAGE_ROOT, newFilePath)
-        os.makedirs(os.path.dirname(src_file), exist_ok=True)
-       
-        new_file.file_name = newFileName
         f = DjangoFile(open(file, 'br'))
-        new_file.upload.save(newFileName, f)
+        new_file.upload.save(fileName, f)
 
     add_content_size(parent_folder, total_file_size)
 

--- a/management/commands/relocate_filemanager_uploads.py
+++ b/management/commands/relocate_filemanager_uploads.py
@@ -1,0 +1,83 @@
+import os
+import uuid
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from django_filemanager.models import File
+from django_filemanager.upload_to import storage_path
+
+
+class Command(BaseCommand):
+    """
+    This class describes the command to be executed
+    """
+
+    help = """Relocate every file whose stored path still holds the name it was
+    uploaded under, so that the path stops being derivable from the owner's
+    identifier and the name of the document. File.file_name keeps that name for
+    display and download. Safe to interrupt and to run again: a file is linked
+    to its new path before the row is written and unlinked from the old path
+    only after, so an interrupted run never leaves a row without a file.
+    Usage: django-admin relocate_filemanager_uploads [--dry-run]
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('--dry-run', action='store_true')
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        relocated = already_opaque = missing = 0
+
+        for file in File.objects.select_related(
+                'folder__filemanager').order_by('pk').iterator():
+            name = file.upload.name
+            if not name or is_opaque(name):
+                already_opaque += 1
+                continue
+
+            source = os.path.join(settings.NETWORK_STORAGE_ROOT, name)
+            if not os.path.isfile(source):
+                self.stderr.write(f'{file.pk}: nothing stored at {name}')
+                missing += 1
+                continue
+
+            # The extension comes off the stored name rather than off
+            # file_name, because it is the stored name that is served
+            destination_name = storage_path(
+                file.folder, os.path.basename(name))
+            self.stdout.write(f'{file.pk}: {name} -> {destination_name}')
+            relocated += 1
+            if dry_run:
+                continue
+
+            destination = os.path.join(
+                settings.NETWORK_STORAGE_ROOT, destination_name)
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            os.link(source, destination)
+            File.objects.filter(pk=file.pk).update(
+                upload=destination_name,
+                file_name=file.file_name or os.path.basename(name),
+            )
+            os.remove(source)
+
+        summary = (f'{relocated} relocated, {already_opaque} already opaque, '
+                   f'{missing} missing')
+        if dry_run:
+            self.stdout.write(self.style.WARNING(f'Dry run: {summary}'))
+        else:
+            self.stdout.write(self.style.SUCCESS(summary))
+
+
+def is_opaque(name):
+    """
+    Report whether a stored path already carries an opaque name
+    :param name: the stored path of a file
+    :return: whether its last segment is a UUID
+    """
+
+    try:
+        uuid.UUID(os.path.splitext(os.path.basename(name))[0])
+    except ValueError:
+        return False
+    return True

--- a/mystorage.py
+++ b/mystorage.py
@@ -2,10 +2,7 @@ from django.core.files.storage import FileSystemStorage
 
 
 class CleanFileNameStorage(FileSystemStorage):
-
-    def get_valid_name(self, name):
-        """
-        Return a filename, based on the provided filename, that's suitable for
-        use in the target storage system.
-        """
-        return name
+    """
+    Named by the migrations. Its get_valid_name used to return the uploaded
+    filename unchanged, which switched off the sanitisation Django applies.
+    """

--- a/serializers.py
+++ b/serializers.py
@@ -54,6 +54,15 @@ class FileSerializer(ModelSerializer):
         fields = '__all__'
         read_only_fields = ['shared_users']
 
+    def validate_file_name(self, value):
+        """
+        Keep a display name a name: it is never a path
+        :param value: the display name the caller asked for
+        :return: the same name, without any directory the caller wrote into it
+        """
+
+        return os.path.basename(value)
+
     def get_file_url(self, obj):
         if(not obj.folder.filemanager.is_public):
             return obj.upload.name

--- a/upload_to.py
+++ b/upload_to.py
@@ -1,24 +1,60 @@
-import mimetypes
 import os
+import re
 import uuid
 
-from django.conf import settings
 from django.utils.deconstruct import deconstructible
+
+EXTENSION = re.compile(r'\.[a-z0-9]{1,16}')
+
+
+def storage_path(folder, filename):
+    """
+    Compute where a file of a folder is stored, relative to the storage root.
+    The leaf is an opaque UUID, so that knowing who owns a file and what the
+    file is called does not give away where it is kept. File.file_name carries
+    the name to display and to download the file under.
+    :param folder: the folder the file belongs to
+    :param filename: the original name of the file, used for the extension
+    :return: the path to store the file at
+    """
+
+    filemanager = folder.filemanager
+    return os.path.join(
+        'public' if filemanager.is_public else 'protected',
+        str(filemanager.filemanager_name),
+        str(folder.path),
+        opaque_name(filename),
+    )
+
+
+def opaque_name(filename):
+    """
+    Compute the stored name of a file, keeping only its extension
+    :param filename: the original name of the file
+    :return: a UUID carrying the extension of the original name
+    """
+
+    extension = os.path.splitext(filename)[1].lower()
+    if not EXTENSION.fullmatch(extension):
+        extension = ''
+    return f'{uuid.uuid4()}{extension}'
 
 
 @deconstructible
 class UploadTo:
     """
-    This utility provides a cross-application, cross-model generalised way for
-    storing files based on a UUID naming scheme
+    The upload_to of File.upload. It takes the arguments the field was declared
+    with, which the migrations hold, and reads the destination off the folder.
     """
 
-    def __init__(self, app_name, folder_name, file_manager=False, base_location=''):
+    def __init__(self, app_name, folder_name, file_manager=False,
+                 base_location=''):
         """
         Initialise a callable instance of the class with the given parameters
         :param app_name: the name of the app using this utility
         :param folder_name: the name of the folder where to write the file
         :param file_manager: whether the app using this utility is File Manager
+        :param base_location: the root the destination is written under
         """
 
         self.app_name = app_name
@@ -28,65 +64,10 @@ class UploadTo:
 
     def __call__(self, instance, filename):
         """
-        Compute the location of where to store the file, removing any
-        existing file with the same name
+        Compute the location of where to store the file
         :param instance: the instance to which file is being uploaded
         :param filename: the original name of the file, used for the extension
-        :return: the path to the uploaded image
+        :return: the path to the uploaded file
         """
 
-        # Path upto the file
-        if self.file_manager:
-            if type(instance).__name__ == 'File':
-                folder_name = str(instance.folder.path)
-                self.app_name = str(
-                    instance.folder.filemanager.filemanager_name)
-            else:
-                folder_name = self.folder_name
-            if type(instance).__name__ == 'FileManager':
-
-                if instance.is_public:
-                    self.base_location = 'public'
-                else:
-                    self.base_location = 'protected'
-
-            elif type(instance).__name__ == 'File':
-                if instance.folder.filemanager.is_public:
-                    self.base_location = 'public'
-                else:
-                    self.base_location = 'protected'
-
-        else:
-            folder_name = self.folder_name
-
-        path = os.path.join(
-            self.app_name,
-            folder_name,
-        )
-        updated_filename = self.get_file_name(path, filename)
-        # Full path to the file
-        destination = os.path.join(
-            self.base_location,
-            self.app_name,
-            folder_name,
-            updated_filename,
-        )
-        return destination
-
-    def get_file_name(self, path, filename):
-        """
-        Return Updated file name in case of file already exists 
-        :param path: path of folder in which the file will be stored 
-        :param filename: the original name of the file
-        :return: the path to the uploaded image
-        """
-        
-        name, ext = os.path.splitext(filename)
-        newpath = path+'/'+filename
-        newname = filename
-        counter = 0
-        while os.path.exists(newpath):
-            newname = name+'_' + str(counter) + ext
-            newpath = path+'/'+newname
-            counter = counter + 1
-        return newname
+        return storage_path(instance.folder, filename)

--- a/views/file.py
+++ b/views/file.py
@@ -1,4 +1,3 @@
-from genericpath import isfile
 import os
 import shutil
 import re
@@ -21,8 +20,8 @@ from django_filemanager.models import Folder, File, FileManager, BASE_PROTECTED_
 from django_filemanager.permissions import IsOwner
 from django_filemanager.constants import BATCH_SIZE
 from django_filemanager.utils import add_content_size, reduce_content_size, is_file_shared
-from django_filemanager.views.utils.file import create_file, file_exists
-from django_filemanager.views.utils.copy_folder import sanitize_folder_name, shift_single_folder, folder_exists
+from django_filemanager.views.utils.file import create_file
+from django_filemanager.views.utils.copy_folder import sanitize_folder_name, shift_single_folder
 
 
 class FileAccessView(APIView):
@@ -114,9 +113,13 @@ class FileView(viewsets.ModelViewSet):
             return HttpResponse('Space limit exceeded', status=status.HTTP_400_BAD_REQUEST)
 
         starred = data.get('starred') == 'True'
+        # The stored name is opaque, so file_name is the only record of what
+        # the file is called, and it is what the extension is taken from
+        file_name = os.path.basename(data.get('file_name') or upload.name)
+        upload.name = file_name
 
         new_file = File.objects.create(upload=upload,
-                                       file_name=data.get('file_name'),
+                                       file_name=file_name,
                                        extension=data.get('extension'),
                                        starred=starred,
                                        size=file_size,
@@ -154,8 +157,9 @@ class FileView(viewsets.ModelViewSet):
         add_content_size(parent_folder, total_file_size)
 
         for upload, name, extension, flag in zip(uploads, names, extensions, flags):
+            upload.name = os.path.basename(name or upload.name)
             new_file = File(upload=upload,
-                            file_name=name,
+                            file_name=upload.name,
                             extension=extension,
                             starred=flag == 'True',
                             size=upload.size,
@@ -165,45 +169,6 @@ class FileView(viewsets.ModelViewSet):
         files = File.objects.bulk_create(batch, BATCH_SIZE[0])
         serializer = self.get_serializer(files, many=True)
         return Response(serializer.data)
-
-    def update(self, request, *args, **kwargs):
-        file = self.get_object()
-        # A name is a name, never a path: basename keeps the rename in the folder
-        file_name = os.path.basename(request.data.get('file_name') or '')
-        if file_name and file_name != file.file_name:
-            folder_name = str(file.folder.path)
-
-            if(file.folder.filemanager.is_public):
-                base_location = "public"
-            else:
-                base_location = "protected"
-
-            app_name = str(
-                file.folder.filemanager.filemanager_name)
-            path = os.path.join(
-                base_location,
-                app_name,
-                folder_name,
-            )
-            updated_filename = file_name
-            # Full path to the file
-            initial_destination = os.path.join(
-                settings.NETWORK_STORAGE_ROOT,
-                file.upload.name
-            )
-            final_destination = os.path.join(
-                settings.NETWORK_STORAGE_ROOT,
-                path,
-                updated_filename,
-            )
-            upload_name = os.path.join(
-                path,
-                updated_filename
-            )
-            os.rename(initial_destination, final_destination)
-            file.upload.name = str(upload_name)
-            file.save()
-        return super().update(request, *args, **kwargs)
 
     @action(detail=False, methods=['post'])
     def bulk_delete(self, request):
@@ -298,30 +263,18 @@ class FileView(viewsets.ModelViewSet):
 
         if root_folder.content_size + file.size > root_folder.max_space:
             return HttpResponse('Space limit exceeded', status=status.HTTP_400_BAD_REQUEST)
-        
-        if folder.filemanager.is_public:
-            final_base_location = 'public'
-        else:
-            final_base_location = 'protected'
 
-        final_filemanager_path = os.path.join(
-            settings.NETWORK_STORAGE_ROOT, final_base_location, folder.filemanager.filemanager_name)
-        folder_path = os.path.join(final_filemanager_path, folder.get_path())
+        file_name = file.file_name
+        if folder.files.filter(file_name=file_name).exists():
+            return HttpResponse("a file with same name already exists", status=status.HTTP_400_BAD_REQUEST)
 
         initial_path = os.path.join(
             settings.NETWORK_STORAGE_ROOT, file.path)
-        file_name = file.file_name
-        final_destination_path = os.path.join(folder_path,
-                                              file_name)
-        if not os.path.exists(final_destination_path):
-            if not os.path.isdir(folder_path):
-                os.mkdir(folder_path)
-            shutil.copy(initial_path, final_destination_path)
-            new_file = create_file(folder, file_name, f".{file.extension}", file.size)
-            add_content_size(folder, file.size)
-            return HttpResponse('File Copied successfully', status=status.HTTP_200_OK)
-        else:
-            return HttpResponse("a file with same name already exists", status=status.HTTP_400_BAD_REQUEST)
+        new_file = create_file(folder, file_name, f".{file.extension}", file.size)
+        os.makedirs(os.path.dirname(new_file.upload.path), exist_ok=True)
+        shutil.copy(initial_path, new_file.upload.path)
+        add_content_size(folder, file.size)
+        return HttpResponse('File Copied successfully', status=status.HTTP_200_OK)
 
     @action(methods=['post'], detail=False, url_name='cut_file', url_path='cut_file')
     def cut(self, request):
@@ -347,32 +300,20 @@ class FileView(viewsets.ModelViewSet):
 
         if root_folder.content_size + file.size > root_folder.max_space:
             return HttpResponse('Space limit exceeded', status=status.HTTP_400_BAD_REQUEST)
-        
-        if folder.filemanager.is_public:
-            final_base_location = 'public'
-        else:
-            final_base_location = 'protected'
 
-        final_filemanager_path = os.path.join(
-            settings.NETWORK_STORAGE_ROOT, final_base_location, folder.filemanager.filemanager_name)
-        folder_path = os.path.join(final_filemanager_path, folder.get_path())
+        file_name = file.file_name
+        if folder.files.filter(file_name=file_name).exists():
+            return HttpResponse("a file with same name already exists", status=status.HTTP_400_BAD_REQUEST)
 
         initial_path = os.path.join(
             settings.NETWORK_STORAGE_ROOT, file.path)
-        file_name = file.file_name
-        final_destination_path = os.path.join(folder_path,
-                                              file_name)
-        if not os.path.exists(final_destination_path):
-            if not os.path.isdir(folder_path):
-                os.mkdir(folder_path)
-            shutil.move(initial_path, final_destination_path)
-            new_file = create_file(folder, file_name, f".{file.extension}", file.size)
-            add_content_size(folder, file.size)
-            reduce_content_size(file.folder, file.size)
-            file.delete()
-            return HttpResponse('File Cut successfully', status=status.HTTP_200_OK)
-        else:
-            return HttpResponse("a file with same name already exists", status=status.HTTP_400_BAD_REQUEST)
+        new_file = create_file(folder, file_name, f".{file.extension}", file.size)
+        os.makedirs(os.path.dirname(new_file.upload.path), exist_ok=True)
+        shutil.move(initial_path, new_file.upload.path)
+        add_content_size(folder, file.size)
+        reduce_content_size(file.folder, file.size)
+        file.delete()
+        return HttpResponse('File Cut successfully', status=status.HTTP_200_OK)
 
     @action(methods=['post'], detail=False, url_name='zip', url_path='zip')
     def zip(self, request):
@@ -414,26 +355,23 @@ class FileView(viewsets.ModelViewSet):
             settings.NETWORK_STORAGE_ROOT, base_location, parent_folder.filemanager.filemanager_name)
         for content in contents:
             path = os.path.join(directory_path, content)
-            final_destination = os.path.join(parent_folder.path, content)
-            if os.path.isdir(path) and not os.path.exists(final_destination):
+            if os.path.isdir(path):
                 content = sanitize_folder_name(os.path.join(
                     filemanager_path, parent_folder.get_path()), content)
+                destination = os.path.join(
+                    filemanager_path, parent_folder.get_path(), content)
+                os.makedirs(os.path.dirname(destination), exist_ok=True)
+                shutil.move(path, destination)
                 shift_single_folder(
-                    path, parent_folder, filemanager_path, parent_folder.filemanager, content)
-                shutil.move(path, os.path.join(
-                    filemanager_path, parent_folder.get_path(), content))
-            elif os.path.isfile(path) and not os.path.exists(final_destination):
-                parent_path = filemanager_path
-                if not os.path.isdir(parent_path):
-                    os.mkdir(parent_path)
-                folder_exists(parent_folder, parent_path)
-                parent_path = os.path.join(parent_path, parent_folder.get_path())
-                content = file_exists(parent_path, content)
+                    destination, parent_folder, filemanager_path,
+                    parent_folder.filemanager, content)
+            elif os.path.isfile(path):
                 extension = os.path.splitext(path)[1]
                 filesize = os.path.getsize(path)
                 file_obj = create_file(
                     parent_folder, content, extension, filesize)
-                shutil.copy(path, os.path.join(
-                    parent_path, content))
+                os.makedirs(
+                    os.path.dirname(file_obj.upload.path), exist_ok=True)
+                shutil.copy(path, file_obj.upload.path)
         add_content_size(parent_folder, size)
         return HttpResponse('Created', status=status.HTTP_200_OK)

--- a/views/folder.py
+++ b/views/folder.py
@@ -290,10 +290,9 @@ class FolderViewSet(viewsets.ModelViewSet):
         final_destination_path = os.path.join(final_folder_path,
                                               folder_name)
         if not os.path.exists(final_destination_path):
-            if not os.path.isdir(final_folder_path):
-                os.mkdir(final_folder_path)
-            shift_single_folder(initial_folder_path, final_folder, final_filemanager_path, final_folder.filemanager, folder_name)
+            os.makedirs(final_folder_path, exist_ok=True)
             shutil.move(initial_folder_path, final_destination_path)
+            shift_single_folder(final_destination_path, final_folder, final_filemanager_path, final_folder.filemanager, folder_name)
             reduce_content_size(initial_folder.parent, initial_folder.content_size)
             initial_folder.delete()
             return HttpResponse('Folder Cut successfully', status=status.HTTP_200_OK)
@@ -347,10 +346,9 @@ class FolderViewSet(viewsets.ModelViewSet):
         final_destination_path = os.path.join(final_folder_path,
                                               folder_name)
         if not os.path.exists(final_destination_path):
-            if not os.path.isdir(final_folder_path):
-                os.mkdir(final_folder_path)
-            shift_single_folder(initial_folder_path, final_folder, final_filemanager_path, final_folder.filemanager, folder_name)
+            os.makedirs(final_folder_path, exist_ok=True)
             shutil.copytree(initial_folder_path, final_destination_path)
+            shift_single_folder(final_destination_path, final_folder, final_filemanager_path, final_folder.filemanager, folder_name)
             return HttpResponse('Folder Copied successfully', status=status.HTTP_200_OK)
         else:
             return HttpResponse("a folder with same name already exists", status=status.HTTP_400_BAD_REQUEST)

--- a/views/utils/copy_folder.py
+++ b/views/utils/copy_folder.py
@@ -1,11 +1,6 @@
-from genericpath import isdir
 import os
 import re
 import shutil
-import subprocess
-
-from django.core.files import File as DjangoFile
-from django.conf import settings
 
 from django_filemanager.models import Folder
 from django_filemanager.views.utils.file import create_file
@@ -35,53 +30,36 @@ def sanitize_folder_name(parent_folder_path, folder_name, freq=0):
     else:
         return folder_name
 
-def folder_exists(parent_folder, filemanager_path):
-    """This function recursively checks whether parent folders exists or not and creates them if needed
-
-    Arg: 
-        parent_folder (instance): parent folder of file
-        filemanager_path (str): path of filemanager
-    """
-    if parent_folder.parent is None and not os.path.isdir(os.path.join(filemanager_path, parent_folder.path)):
-        os.mkdir(os.path.join(filemanager_path, parent_folder.path))
-
-    elif parent_folder.parent is None and os.path.isdir(os.path.join(filemanager_path, parent_folder.path)):
-        return
-
-    else:
-        if not os.path.isdir(os.path.join(filemanager_path, parent_folder.parent.path)):
-            folder_exists(parent_folder.parent, filemanager_path)
-        
-        if not os.path.isdir(os.path.join(filemanager_path, parent_folder.path)):
-            os.mkdir(os.path.join(filemanager_path, parent_folder.path))
-
 
 def shift_single_folder(folder_path, parent_folder, filemanager_path, filemanager, foldername):
     """This function creates a new folder model and loops through its content
 
+    The tree is expected to already sit at folder_path. Every file it holds is
+    moved to the opaque path its new model names.
+
     Args:
-        folder_path (str): temporary folder path
+        folder_path (str): path of the folder to take over
         parent_folder (instance): instance of parent folder
         filemanager_path (str): path of filemanager
         filemanager (instance): instance of filemanager
         foldername (str): folder name
     """
-    os.listdir(folder_path)
-
     folder_size = os.path.getsize(folder_path)
 
     new_folder = Folder.objects.create(folder_name=foldername, parent=parent_folder,
                                        filemanager=parent_folder.filemanager, root=parent_folder.root, person=parent_folder.person,
-                                       path=os.path.join(parent_folder.path, '/', foldername), content_size=folder_size)
+                                       content_size=folder_size)
 
     for file_or_dir in os.listdir(folder_path):
-        if os.path.isfile(os.path.join(folder_path, file_or_dir)) and not os.path.exists(os.path.join(new_folder.path, file_or_dir)):
-            extension = os.path.splitext(
-                os.path.join(folder_path, file_or_dir))[-1]
-            file_size = os.path.getsize(os.path.join(folder_path, file_or_dir))
+        path = os.path.join(folder_path, file_or_dir)
+        if os.path.isfile(path):
+            extension = os.path.splitext(path)[-1]
+            file_size = os.path.getsize(path)
             add_content_size(new_folder, file_size)
             file_obj = create_file(
                 new_folder, file_or_dir, extension, file_size)
-        elif os.path.isdir(os.path.join(folder_path, file_or_dir)) and not os.path.exists(os.path.join(new_folder.path, file_or_dir)):
-            shift_single_folder(os.path.join(
-                folder_path, file_or_dir), new_folder, filemanager_path, filemanager, file_or_dir)
+            os.makedirs(os.path.dirname(file_obj.upload.path), exist_ok=True)
+            shutil.move(path, file_obj.upload.path)
+        elif os.path.isdir(path):
+            shift_single_folder(
+                path, new_folder, filemanager_path, filemanager, file_or_dir)

--- a/views/utils/file.py
+++ b/views/utils/file.py
@@ -1,36 +1,5 @@
-from fileinput import filename
-import os
-import subprocess
-
 from django_filemanager.models import File
-
-
-def file_exists(parent_folder_path, file_name, freq=0):
-    """This function checks whether a file with same name exists
-
-    Args:
-        parent_folder_path (str): path of parent folder
-        file_name (str): name of file
-        freq (int, optional): Frequency of files with same name. Defaults to 0.
-
-    Returns:
-        str: correct file name
-    """
-    if os.path.exists(os.path.join(parent_folder_path, file_name)):
-        freq = freq + 1
-        filename_content = file_name.split('.')
-        if freq > 1:
-            filename_content[-2] = str(freq).join(
-                filename_content[-2].rsplit(filename_content[-2][-1:], 1))
-        else:
-            filename_content[-2] = filename_content[-2]+str(freq)
-        filename_content[-1] = '.' + filename_content[-1]
-        new_filename = ''
-        for content in filename_content:
-            new_filename = new_filename+content
-        return file_exists(parent_folder_path, new_filename, freq)
-    else:
-        return file_name
+from django_filemanager.upload_to import storage_path
 
 
 def create_file(parent_folder, file_name, extension, file_size):
@@ -43,17 +12,10 @@ def create_file(parent_folder, file_name, extension, file_size):
         file_size (int): size of file
 
     Returns:
-        instance: new file instance 
+        instance: new file instance
     """
-    path = os.path.join(parent_folder.get_path(), file_name)
     new_file = File(file_name=file_name, extension=extension[1:],
                     starred=False, size=file_size, folder=parent_folder)
-    if parent_folder.filemanager.is_public:
-        base_location = 'public'
-    else:
-        base_location = 'protected'
-
-    new_file.upload.name = base_location+'/' + \
-        str(parent_folder.filemanager.filemanager_name)+'/'+str(path)
+    new_file.upload.name = storage_path(parent_folder, file_name)
     new_file.save()
     return new_file


### PR DESCRIPTION
### Merge order

This is stacked on `security/remove-eval` and targets that branch, so **PR #80 has to merge first**. It touches `serializers.py`, `views/file.py` and `views/folder.py`, which #80 also changes, and it builds on the per-object authorisation #80 adds. If #80 is retargeted or closed, this needs rebasing onto whatever carries those changes.

### Summary

This closes F-8, the hardening #80 deliberately left out. Every destination was built as `base_location / filemanager_name / folder.path / filename` in `upload_to.py`, the root folder name is the person's username, which is their enrolment or employee number, and `CleanFileNameStorage.get_valid_name` returned the uploaded filename unchanged, which switched off the sanitisation Django would otherwise apply to it. A stored path therefore followed from a person's identifier and the name of the document, with nothing else needed:

```
protected/R Drive/21114065/Documents/Medical Certificate.pdf
```

Destinations now come from one function, `storage_path` in `upload_to.py`, which keeps the folder layout and gives the file a UUID leaf carrying only its extension, the way `formula_one/utils/upload_to.py` already does. `File.file_name` already held the name to display and to download under, so the interface and the `Content-Disposition` header are unaffected. `FileView.create` now falls back to the uploaded file's name when the payload carries no `file_name`, because that field is from now on the only record of what a file is called, and takes the stored extension from it.

**The other writers of a destination followed.** `create_file` in `views/utils/file.py` built the same path by hand, and it is what `copy`, `cut`, the zip upload and `shift_single_folder` use, so a fix confined to `upload_to.py` would have left every one of those still writing readable paths. It now asks `storage_path` as well, and each caller places the file at `new_file.upload.path` rather than at a name it composed itself. Folder copy and cut place the tree first and take it over second, since the files have to exist before they can be moved to the paths their rows name.

Three helpers existed only to keep two documents of the same name from colliding on disk. A UUID leaf cannot collide, so `file_exists`, `UploadTo.get_file_name` and `add_all_contents.get_file_name` are gone, along with `folder_exists`, which was `os.makedirs`. A rename no longer moves anything on disk, so `FileView.update` is gone too; the basename guard it carried moved into `FileSerializer.validate_file_name`, where it also covers writes that go through the serializer.

**Existing files.** `relocate_filemanager_uploads` relocates what is already stored. It takes the extension off the stored name rather than off `file_name`, because it is the stored name that nginx serves, and it backfills `file_name` from the stored name where a row has none, so no display name is lost. It is safe to interrupt and to run again:

- it links a file to its new path, then writes the row, then unlinks the old path, so an interrupted run never leaves a row pointing at a file that is not there;
- an interrupt before the row is written leaves the old path in place and a re-run redoes that file, leaving one orphaned UUID that costs nothing but the inode;
- an interrupt after the row is written leaves the old link on disk until it is cleaned by hand, `find $NETWORK_STORAGE_ROOT -type f -links +1`;
- a row whose file is already missing is reported and skipped rather than touched;
- `--dry-run` prints every move and changes nothing.

`FileAccessView` resolves a request path by looking the row up on the value it stores, so it keeps working throughout: a row not yet relocated resolves by its old path, a relocated one by its new path, and both are always in step with the disk. A link handed out before the migration and kept afterwards will 404, and the `pk` branch of that view still serves it.

### The decision that is not mine to make

**Files in a public filemanager are relocated too, and that breaks any deep link to them held outside Channeli.** `location /external/public` in nginx is not `internal`, so those files are served by path with no authentication at all, which makes a guessable path there worth more than a guessable path under `protected/`, and per-object authorisation does not cover them. That is the case for relocating them. Against it: the API builds those URLs fresh from `base_public_url` on every serialisation, so anything reading Channeli keeps working, but a URL someone pasted into another site will not.

Please run `--dry-run` first and look at what it reports under `public/`. If any of it is linked from outside, say so and the command can skip public filemanagers.

### Not addressed here

`remove_folder` in `models.py` builds its path from `filemanager_url_path` where every other path uses `filemanager_name`, so deleting a folder silently fails to remove anything from disk. It is a one-word fix that turns a no-op into an `rmtree` on a path I cannot verify against production, so it is not in this PR.

### Test plan

No test suite exists in this repository. Three throwaway harnesses ran against the real models, views and serializers on sqlite, each run once before the change and once after.

**The finding itself.** A person whose username is `21114065` uploads `Medical Certificate.pdf` into `Documents`.

| | before | after |
| --- | --- | --- |
| stored path equals the path guessed from the enrolment number and the document name | yes | no |
| `File.objects.filter(upload=<guess>)` resolves | yes | no |
| stored leaf | `Medical Certificate.pdf` | `78aff7fe-…-5ea0ba7666ba.pdf` |
| `file_name` | `Medical Certificate.pdf` | `Medical Certificate.pdf` |
| `CleanFileNameStorage.get_valid_name('../../Fee Receipt.pdf')` | `../../Fee Receipt.pdf` | `....Fee_Receipt.pdf`, as `FileSystemStorage` gives |

**Every path that writes a file, through the views.** 32 checks, all passing after the change. Run against the current `security/remove-eval`, 8 of them fail, which is what says they are checking something: upload, rename, copy, cut and each of the three files in a zip all wrote a readable leaf, and the rename moved the file on disk.

| Case | Result |
| --- | --- |
| upload stores an opaque leaf, keeps its display name, and the bytes are at the path the row gives | pass |
| rename changes `file_name`, leaves the stored path and the file alone | pass |
| copy writes its own opaque path with the same bytes, and a second copy of the same name is refused | pass |
| cut carries the bytes to a new opaque path and leaves nothing at the old one | pass |
| a zip of a nested tree stores all three files opaquely, at the paths their rows give, and creates the folders | pass |
| every leaf under the storage root is a UUID | pass |
| the stored path is served with `X-Accel-Redirect` and `Content-Disposition: attachment; filename=Renamed.pdf` | pass |
| the guessable path is not served | pass |

**The management command,** on a seeded tree holding a protected file in a subfolder, a protected file in a root folder, a file in a public filemanager, a row whose file is missing, and a row with no display name.

| Case | Result |
| --- | --- |
| `--dry-run` reports every move and changes no row and no file | pass |
| interrupted after the link, before the row: row unchanged, file still served at the path the row holds | pass |
| interrupted after the row, before the unlink: row is opaque, bytes are reachable, the file is served at its new path, the old link is the only residue | pass |
| protected, public and unnamed files are all relocated, keep their bytes and their extension, and leave their old paths | pass |
| a row with no display name has one backfilled from the stored name | pass |
| a row whose file is gone is reported and left alone | pass |
| the guessable path 404s afterwards and the new path is served | pass |
| a second run relocates nothing and changes nothing | pass |

`python -m py_compile` passes on every changed file. The command was never run against anything but the throwaway tree.

On staging: upload, rename, copy, cut, zip-upload and download a file, and confirm the interface still shows the original filenames while `File.upload` holds UUIDs; then run `relocate_filemanager_uploads --dry-run`, read the report, run it for real, and confirm the same files still download.
